### PR TITLE
Add backup/restore safety and parallel ingest

### DIFF
--- a/scripts/ingest.py
+++ b/scripts/ingest.py
@@ -7,6 +7,7 @@ import requests
 import sys
 import os
 import json
+from concurrent.futures import ThreadPoolExecutor, as_completed
 from datetime import datetime, timezone
 
 from scripts.hashing import compute_chapter_hash
@@ -62,8 +63,8 @@ def create_schema(db):
     db.commit()
 
 
-def fetch_and_ingest_chapter(db, chapter_num: int, now: str | None = None) -> tuple:
-    """Fetch a chapter from API and insert into database."""
+def fetch_chapter(chapter_num: int) -> tuple:
+    """Fetch a chapter from the API. Returns (chapter_num, data) or (chapter_num, None) on error."""
     try:
         chapter_str = f"{chapter_num:02d}"
         url = f"https://hts.usitc.gov/reststop/search?keyword=chapter%20{chapter_str}&limit=5000"
@@ -73,87 +74,92 @@ def fetch_and_ingest_chapter(db, chapter_num: int, now: str | None = None) -> tu
 
         if not isinstance(data, list):
             print(f"Warning: Chapter {chapter_str} returned non-list", file=sys.stderr)
-            return 0, 0
+            return chapter_num, None
 
-        cursor = db.cursor()
-        timestamp = now or datetime.now(timezone.utc).isoformat()
-        content_hash = compute_chapter_hash(data)
-
-        # Insert chapter with content hash and timestamps
-        cursor.execute(
-            """INSERT OR IGNORE INTO chapters
-               (number, description, content_hash, last_changed_at, last_checked_at)
-               VALUES (?, ?, ?, ?, ?)""",
-            (chapter_str, f"Chapter {chapter_str}", content_hash, timestamp, timestamp)
-        )
-
-        # Get chapter id
-        cursor.execute("SELECT id FROM chapters WHERE number = ?", (chapter_str,))
-        chapter_row = cursor.fetchone()
-        chapter_id = chapter_row[0] if chapter_row else None
-
-        entries_inserted = 0
-        duplicates_skipped = 0
-
-        for entry in data:
-            hts_code = entry.get("htsno")
-            if not hts_code:
-                continue
-
-            hts_code = str(hts_code).strip()
-
-            description = entry.get("description") or ""
-            if description:
-                description = str(description).strip()
-
-            indent_val = entry.get("indent", 0)
-            if isinstance(indent_val, str):
-                indent = int(indent_val) if indent_val.isdigit() else 0
-            else:
-                indent = int(indent_val) if indent_val else 0
-
-            units = entry.get("units")
-            unit = ""
-            if isinstance(units, list) and units:
-                unit = str(units[0]).strip() if units[0] else ""
-
-            general_rate = entry.get("general") or ""
-            if general_rate:
-                general_rate = str(general_rate).strip()
-
-            special_rate = entry.get("special") or ""
-            if special_rate:
-                special_rate = str(special_rate).strip()
-
-            column2_rate = entry.get("other") or ""
-            if column2_rate:
-                column2_rate = str(column2_rate).strip()
-
-            footnotes_data = entry.get("footnotes")
-            footnotes_str = ""
-            if footnotes_data:
-                try:
-                    footnotes_str = json.dumps(footnotes_data)
-                except (TypeError, ValueError):
-                    pass
-
-            try:
-                cursor.execute(
-                    """INSERT INTO hts_entries
-                       (hts_code, indent, description, unit, general_rate, special_rate, column2_rate, footnotes, chapter_id)
-                       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)""",
-                    (hts_code, indent, description, unit, general_rate, special_rate, column2_rate, footnotes_str, chapter_id)
-                )
-                entries_inserted += 1
-            except sqlite3.IntegrityError:
-                duplicates_skipped += 1
-
-        db.commit()
-        return entries_inserted, duplicates_skipped
+        return chapter_num, data
 
     except Exception as e:
-        print(f"Error with chapter {chapter_num:02d}: {e}", file=sys.stderr)
-        return 0, 0
+        print(f"Error fetching chapter {chapter_num:02d}: {e}", file=sys.stderr)
+        return chapter_num, None
+
+
+def ingest_chapter(db, chapter_num: int, data: list, now: str | None = None) -> tuple:
+    """Insert a chapter's data into the database. Returns (entries_inserted, duplicates_skipped)."""
+    chapter_str = f"{chapter_num:02d}"
+    cursor = db.cursor()
+    timestamp = now or datetime.now(timezone.utc).isoformat()
+    content_hash = compute_chapter_hash(data)
+
+    # Insert chapter with content hash and timestamps
+    cursor.execute(
+        """INSERT OR IGNORE INTO chapters
+           (number, description, content_hash, last_changed_at, last_checked_at)
+           VALUES (?, ?, ?, ?, ?)""",
+        (chapter_str, f"Chapter {chapter_str}", content_hash, timestamp, timestamp)
+    )
+
+    # Get chapter id
+    cursor.execute("SELECT id FROM chapters WHERE number = ?", (chapter_str,))
+    chapter_row = cursor.fetchone()
+    chapter_id = chapter_row[0] if chapter_row else None
+
+    entries_inserted = 0
+    duplicates_skipped = 0
+
+    for entry in data:
+        hts_code = entry.get("htsno")
+        if not hts_code:
+            continue
+
+        hts_code = str(hts_code).strip()
+
+        description = entry.get("description") or ""
+        if description:
+            description = str(description).strip()
+
+        indent_val = entry.get("indent", 0)
+        if isinstance(indent_val, str):
+            indent = int(indent_val) if indent_val.isdigit() else 0
+        else:
+            indent = int(indent_val) if indent_val else 0
+
+        units = entry.get("units")
+        unit = ""
+        if isinstance(units, list) and units:
+            unit = str(units[0]).strip() if units[0] else ""
+
+        general_rate = entry.get("general") or ""
+        if general_rate:
+            general_rate = str(general_rate).strip()
+
+        special_rate = entry.get("special") or ""
+        if special_rate:
+            special_rate = str(special_rate).strip()
+
+        column2_rate = entry.get("other") or ""
+        if column2_rate:
+            column2_rate = str(column2_rate).strip()
+
+        footnotes_data = entry.get("footnotes")
+        footnotes_str = ""
+        if footnotes_data:
+            try:
+                footnotes_str = json.dumps(footnotes_data)
+            except (TypeError, ValueError):
+                pass
+
+        try:
+            cursor.execute(
+                """INSERT INTO hts_entries
+                   (hts_code, indent, description, unit, general_rate, special_rate, column2_rate, footnotes, chapter_id)
+                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+                (hts_code, indent, description, unit, general_rate, special_rate, column2_rate, footnotes_str, chapter_id)
+            )
+            entries_inserted += 1
+        except sqlite3.IntegrityError:
+            duplicates_skipped += 1
+
+    return entries_inserted, duplicates_skipped
 
 
 def main():
@@ -167,22 +173,35 @@ def main():
         print("Creating database schema...")
         create_schema(db)
 
-        print("Fetching and ingesting HTS data from all 99 chapters...")
+        print("Fetching HTS data from all 99 chapters (parallel)...")
         start_time = time.time()
         now = datetime.now(timezone.utc).isoformat()
+        max_workers = int(os.getenv("HTS_INGEST_WORKERS", "10"))
 
+        # Phase 1: Fetch all chapters in parallel
+        chapter_data = {}
+        fetch_errors = 0
+
+        with ThreadPoolExecutor(max_workers=max_workers) as executor:
+            futures = {executor.submit(fetch_chapter, ch): ch for ch in range(1, 100)}
+            for future in as_completed(futures):
+                chapter_num, data = future.result()
+                if data is not None:
+                    chapter_data[chapter_num] = data
+                else:
+                    fetch_errors += 1
+
+        print(f"  Fetched {len(chapter_data)} chapters ({fetch_errors} errors)")
+
+        # Phase 2: Insert into DB sequentially (SQLite is single-writer)
+        print("Inserting data into database...")
         total_entries = 0
-        total_chapters_done = 0
         total_duplicates = 0
 
-        for ch in range(1, 100):
-            entries, duplicates = fetch_and_ingest_chapter(db, ch, now=now)
+        for ch in sorted(chapter_data.keys()):
+            entries, duplicates = ingest_chapter(db, ch, chapter_data[ch], now=now)
             total_entries += entries
-            total_chapters_done += 1
             total_duplicates += duplicates
-
-            if ch % 10 == 0:
-                print(f"  Completed {ch}/99 chapters ({total_entries} entries loaded so far)...")
 
         duration = time.time() - start_time
 
@@ -191,13 +210,15 @@ def main():
             """INSERT INTO data_freshness
                (last_full_refresh, refresh_duration_secs, chapters_changed, total_chapters)
                VALUES (?, ?, ?, ?)""",
-            (now, round(duration, 2), 99, 99)
+            (now, round(duration, 2), len(chapter_data), 99)
         )
         db.commit()
 
-        print(f"Loaded {total_entries} entries across 99 chapters in {duration:.1f}s")
+        print(f"Loaded {total_entries} entries across {len(chapter_data)} chapters in {duration:.1f}s")
         if total_duplicates > 0:
             print(f"(Skipped {total_duplicates} duplicate HTS codes)")
+        if fetch_errors > 0:
+            print(f"Warning: {fetch_errors} chapters failed to fetch", file=sys.stderr)
 
     except Exception as e:
         print(f"Error: {e}", file=sys.stderr)

--- a/scripts/refresh.py
+++ b/scripts/refresh.py
@@ -10,6 +10,7 @@ re-ingest. Per-chapter timestamps track when each chapter was last checked
 and when its content actually changed.
 """
 
+import shutil
 import sqlite3
 import sys
 import time
@@ -126,14 +127,26 @@ def main():
         print(f"(probed in {fetch_duration:.1f}s)")
         print("Running re-ingest...")
 
-    # Remove old database so ingest creates fresh tables
-    if DB_PATH.exists():
+    # Back up existing database before re-ingesting
+    backup_path = DATA_DIR / "hts.db.backup"
+    had_existing_db = DB_PATH.exists()
+
+    if had_existing_db:
+        print(f"Backing up existing database to {backup_path}...")
+        shutil.copy2(str(DB_PATH), str(backup_path))
         DB_PATH.unlink()
 
     exit_code = run_ingest()
     if exit_code != 0:
         print("Ingest failed!", file=sys.stderr)
+        if had_existing_db and backup_path.exists():
+            print("Restoring database from backup...", file=sys.stderr)
+            shutil.copy2(str(backup_path), str(DB_PATH))
         sys.exit(exit_code)
+
+    # Success — remove backup
+    if backup_path.exists():
+        backup_path.unlink()
 
     total_duration = time.time() - start_time
     print(f"Refresh complete in {total_duration:.1f}s.")

--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -1,0 +1,199 @@
+"""Tests for scripts/ingest.py — parallel ingest.
+
+Red-green TDD: These tests fail on main (fetch_chapter and ingest_chapter
+don't exist as separate functions) and pass on this branch.
+"""
+
+import sqlite3
+import json
+import pytest
+from unittest.mock import patch, MagicMock
+
+import sys
+import os
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "scripts"))
+
+from scripts.ingest import create_schema, fetch_chapter, ingest_chapter
+
+
+@pytest.fixture
+def empty_db(tmp_path):
+    """Create an empty database with schema."""
+    db_path = tmp_path / "test.db"
+    db = sqlite3.connect(str(db_path))
+    create_schema(db)
+    yield db
+    db.close()
+
+
+# --- fetch_chapter tests ---
+
+
+def test_fetch_chapter_returns_tuple():
+    """fetch_chapter returns (chapter_num, data) tuple."""
+    mock_response = MagicMock()
+    mock_response.json.return_value = [
+        {"htsno": "0101.21.00", "description": "Horses", "indent": 2,
+         "units": ["No."], "general": "Free", "special": "Free", "other": "20%"}
+    ]
+    mock_response.raise_for_status = MagicMock()
+
+    with patch("scripts.ingest.requests.get", return_value=mock_response):
+        chapter_num, data = fetch_chapter(1)
+
+    assert chapter_num == 1
+    assert isinstance(data, list)
+    assert len(data) == 1
+
+
+def test_fetch_chapter_returns_none_on_error():
+    """fetch_chapter returns (chapter_num, None) on network error."""
+    with patch("scripts.ingest.requests.get", side_effect=Exception("Network error")):
+        chapter_num, data = fetch_chapter(5)
+
+    assert chapter_num == 5
+    assert data is None
+
+
+def test_fetch_chapter_returns_none_for_non_list():
+    """fetch_chapter returns None data when API returns non-list."""
+    mock_response = MagicMock()
+    mock_response.json.return_value = {"error": "not found"}
+    mock_response.raise_for_status = MagicMock()
+
+    with patch("scripts.ingest.requests.get", return_value=mock_response):
+        chapter_num, data = fetch_chapter(99)
+
+    assert chapter_num == 99
+    assert data is None
+
+
+# --- ingest_chapter tests ---
+
+
+def test_ingest_chapter_inserts_entries(empty_db):
+    """ingest_chapter inserts entries and returns count."""
+    data = [
+        {"htsno": "0101.21.00", "description": "Horses", "indent": 2,
+         "units": ["No."], "general": "Free", "special": "Free", "other": "20%"},
+        {"htsno": "0101.29.00", "description": "Other horses", "indent": 2,
+         "units": ["No."], "general": "Free", "special": "", "other": ""},
+    ]
+
+    entries, duplicates = ingest_chapter(empty_db, 1, data)
+
+    assert entries == 2
+    assert duplicates == 0
+
+
+def test_ingest_chapter_creates_chapter_record(empty_db):
+    """ingest_chapter creates a chapter record in the chapters table."""
+    data = [
+        {"htsno": "0101.21.00", "description": "Horses", "indent": 2,
+         "units": ["No."], "general": "Free", "special": "Free", "other": "20%"},
+    ]
+
+    ingest_chapter(empty_db, 1, data)
+
+    cursor = empty_db.cursor()
+    cursor.execute("SELECT number, description FROM chapters WHERE number = '01'")
+    row = cursor.fetchone()
+    assert row is not None
+    assert row[0] == "01"
+
+
+def test_ingest_chapter_stores_content_hash(empty_db):
+    """ingest_chapter computes and stores a content hash for the chapter."""
+    data = [
+        {"htsno": "0101.21.00", "description": "Horses", "indent": 2,
+         "units": ["No."], "general": "Free", "special": "Free", "other": "20%"},
+    ]
+
+    ingest_chapter(empty_db, 1, data)
+
+    cursor = empty_db.cursor()
+    cursor.execute("SELECT content_hash FROM chapters WHERE number = '01'")
+    row = cursor.fetchone()
+    assert row is not None
+    assert row[0] is not None
+    assert len(row[0]) == 64  # SHA256 hex digest
+
+
+def test_ingest_chapter_skips_duplicates(empty_db):
+    """ingest_chapter counts duplicate HTS codes."""
+    data = [
+        {"htsno": "0101.21.00", "description": "Horses", "indent": 2,
+         "units": ["No."], "general": "Free", "special": "Free", "other": "20%"},
+    ]
+
+    # Insert once
+    ingest_chapter(empty_db, 1, data)
+    empty_db.commit()
+
+    # Insert again — should skip duplicate
+    entries, duplicates = ingest_chapter(empty_db, 1, data)
+    assert entries == 0
+    assert duplicates == 1
+
+
+def test_ingest_chapter_skips_entries_without_htsno(empty_db):
+    """Entries without htsno field are skipped."""
+    data = [
+        {"description": "No code entry", "indent": 0},
+        {"htsno": "0101.21.00", "description": "Horses", "indent": 2,
+         "units": ["No."], "general": "Free", "special": "Free", "other": "20%"},
+    ]
+
+    entries, duplicates = ingest_chapter(empty_db, 1, data)
+    assert entries == 1  # Only the one with htsno
+
+
+def test_ingest_chapter_handles_string_indent(empty_db):
+    """Indent value can be a string and gets converted to int."""
+    data = [
+        {"htsno": "0101.21.00", "description": "Horses", "indent": "2",
+         "units": ["No."], "general": "Free", "special": "Free", "other": "20%"},
+    ]
+
+    ingest_chapter(empty_db, 1, data)
+    empty_db.commit()
+
+    cursor = empty_db.cursor()
+    cursor.execute("SELECT indent FROM hts_entries WHERE hts_code = '0101.21.00'")
+    assert cursor.fetchone()[0] == 2
+
+
+def test_ingest_chapter_handles_footnotes(empty_db):
+    """Footnotes data is serialized to JSON string."""
+    data = [
+        {"htsno": "0101.21.00", "description": "Horses", "indent": 2,
+         "units": ["No."], "general": "Free", "special": "Free", "other": "20%",
+         "footnotes": [{"id": "1", "text": "See note"}]},
+    ]
+
+    ingest_chapter(empty_db, 1, data)
+    empty_db.commit()
+
+    cursor = empty_db.cursor()
+    cursor.execute("SELECT footnotes FROM hts_entries WHERE hts_code = '0101.21.00'")
+    footnotes = cursor.fetchone()[0]
+    parsed = json.loads(footnotes)
+    assert parsed[0]["id"] == "1"
+
+
+def test_ingest_chapter_stores_timestamps(empty_db):
+    """ingest_chapter stores last_changed_at and last_checked_at timestamps."""
+    data = [
+        {"htsno": "0101.21.00", "description": "Horses", "indent": 2,
+         "units": ["No."], "general": "Free", "special": "Free", "other": "20%"},
+    ]
+
+    ingest_chapter(empty_db, 1, data, now="2026-03-21T00:00:00+00:00")
+
+    cursor = empty_db.cursor()
+    cursor.execute("SELECT last_changed_at, last_checked_at FROM chapters WHERE number = '01'")
+    row = cursor.fetchone()
+    assert row[0] == "2026-03-21T00:00:00+00:00"
+    assert row[1] == "2026-03-21T00:00:00+00:00"

--- a/tests/test_refresh.py
+++ b/tests/test_refresh.py
@@ -1,0 +1,94 @@
+"""Tests for scripts/refresh.py — safe refresh with backup.
+
+Red-green TDD: These tests fail on main (no backup logic exists)
+and pass on this branch.
+"""
+
+import sqlite3
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+import sys
+import os
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "scripts"))
+
+from scripts.refresh import main
+
+
+@pytest.fixture
+def data_dir(tmp_path):
+    """Create a temporary data directory with a fake database."""
+    data = tmp_path / "data"
+    data.mkdir()
+
+    # Create a fake database with test data
+    db_path = data / "hts.db"
+    db = sqlite3.connect(str(db_path))
+    db.execute("CREATE TABLE test (id INTEGER)")
+    db.execute("INSERT INTO test VALUES (42)")
+    db.commit()
+    db.close()
+
+    return data
+
+
+def test_refresh_restores_backup_on_ingest_failure(data_dir):
+    """When ingest fails, the backup is restored so data is not lost."""
+    db_path = data_dir / "hts.db"
+
+    with patch("scripts.refresh.DATA_DIR", data_dir), \
+         patch("scripts.refresh.DB_PATH", db_path), \
+         patch("scripts.refresh.fetch_all_chapter_hashes", return_value={"01": "newhash"}), \
+         patch("scripts.refresh.get_stored_hashes", return_value={"01": "oldhash"}), \
+         patch("scripts.refresh.run_ingest", return_value=1):
+        with pytest.raises(SystemExit):
+            main()
+
+    # After failed ingest, DB should be restored from backup
+    assert db_path.exists(), "Database was lost after failed ingest — backup/restore didn't work"
+    db = sqlite3.connect(str(db_path))
+    result = db.execute("SELECT * FROM test").fetchone()
+    db.close()
+    assert result == (42,), "Restored database doesn't contain original data"
+
+
+def test_refresh_cleans_up_backup_on_success(data_dir):
+    """After successful ingest, the backup file is removed."""
+    db_path = data_dir / "hts.db"
+    backup_path = data_dir / "hts.db.backup"
+
+    with patch("scripts.refresh.DATA_DIR", data_dir), \
+         patch("scripts.refresh.DB_PATH", db_path), \
+         patch("scripts.refresh.fetch_all_chapter_hashes", return_value={"01": "newhash"}), \
+         patch("scripts.refresh.get_stored_hashes", return_value={"01": "oldhash"}), \
+         patch("scripts.refresh.run_ingest", return_value=0):
+        main()
+
+    assert not backup_path.exists(), "Backup file was not cleaned up after successful ingest"
+
+
+def test_refresh_skips_when_up_to_date(data_dir, capsys):
+    """When hashes match, refresh does nothing."""
+    db_path = data_dir / "hts.db"
+
+    # Need chapters table for update_checked_timestamps
+    db = sqlite3.connect(str(db_path))
+    db.execute("CREATE TABLE IF NOT EXISTS chapters (id INTEGER PRIMARY KEY, number TEXT, description TEXT, content_hash TEXT, last_changed_at TEXT, last_checked_at TEXT)")
+    db.execute("""CREATE TABLE IF NOT EXISTS data_freshness (
+        id INTEGER PRIMARY KEY, last_full_refresh TEXT NOT NULL,
+        refresh_duration_secs REAL, chapters_changed INTEGER, total_chapters INTEGER)""")
+    db.commit()
+    db.close()
+
+    with patch("scripts.refresh.DATA_DIR", data_dir), \
+         patch("scripts.refresh.DB_PATH", db_path), \
+         patch("scripts.refresh.fetch_all_chapter_hashes", return_value={"01": "samehash"}), \
+         patch("scripts.refresh.get_stored_hashes", return_value={"01": "samehash"}):
+        main()
+
+    captured = capsys.readouterr()
+    assert "Already up to date" in captured.out


### PR DESCRIPTION
## Summary
- Split `fetch_and_ingest_chapter` into `fetch_chapter` (network) and `ingest_chapter` (DB write) for parallel fetching
- Use `ThreadPoolExecutor` to fetch all 99 chapters in parallel, then insert sequentially (respects SQLite single-writer)
- Worker count configurable via `HTS_INGEST_WORKERS` env var (default 10)
- Add backup/restore to `refresh.py`: backs up `hts.db` before re-ingest, restores on failure

## Test plan
- [x] Ingest failure restores DB from backup (`test_refresh_restores_backup_on_ingest_failure`)
- [x] Successful ingest cleans up backup file (`test_refresh_cleans_up_backup_on_success`)
- [x] Parallel fetch + sequential insert produces identical DB to current sequential ingest
- [x] `HTS_INGEST_WORKERS` env var is respected
- [x] All existing tests still pass (92 passed, 2 skipped)

Closes #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)