### PR TITLE
fix: create browse_chapters SQL view referenced by metadata.json

### DIFF
--- a/scripts/ingest.py
+++ b/scripts/ingest.py
@@ -51,6 +51,18 @@ def create_schema(db):
     cursor.execute("CREATE INDEX idx_hts_code ON hts_entries(hts_code)")
     cursor.execute("CREATE INDEX idx_description ON hts_entries(description)")
 
+    cursor.execute("DROP VIEW IF EXISTS browse_chapters")
+    cursor.execute("""
+    CREATE VIEW browse_chapters AS
+    SELECT c.number  AS chapter,
+           c.description,
+           COUNT(e.id) AS entries
+    FROM   chapters c
+    LEFT JOIN hts_entries e ON e.chapter_id = c.id
+    GROUP BY c.id
+    ORDER BY c.number
+    """)
+
     cursor.execute("""
     CREATE TABLE IF NOT EXISTS data_freshness (
         id                    INTEGER PRIMARY KEY,


### PR DESCRIPTION
## Summary

- `metadata.json` configures a `browse_chapters` table for Datasette, but no such SQL view existed in the codebase, causing errors when users navigate to it
- Adds a `browse_chapters` SQL view to `create_schema()` in `scripts/ingest.py` that joins `chapters` and `hts_entries` to show chapter number, description, and entry count per chapter
- The view columns (`chapter`, `description`, `entries`) match what `metadata.json` expects (sortable on `chapter` and `entries`)

## Test plan

- [x] All 114 tests pass (`docker run --rm hts-local -m pytest tests/ -v`)
- [x] View returns correct data after ingest (`SELECT * FROM browse_chapters LIMIT 5` returns chapter numbers, descriptions, and entry counts)
- [ ] Verify Datasette renders the browse_chapters page without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)