### PR TITLE
fix: add --user root to deploy-datasette Docker data commands

### DIFF
--- a/.github/workflows/deploy-datasette.yml
+++ b/.github/workflows/deploy-datasette.yml
@@ -20,15 +20,15 @@ jobs:
 
       - name: Ingest HTS data
         run: |
-          docker run --rm -v "$(pwd)/data:/app/data" hts-local scripts/ingest.py
+          docker run --rm --user root -v "$(pwd)/data:/app/data" hts-local scripts/ingest.py
 
       - name: Enrich chapter titles
         run: |
-          docker run --rm -v "$(pwd)/data:/app/data" hts-local scripts/chapter_titles.py
+          docker run --rm --user root -v "$(pwd)/data:/app/data" hts-local scripts/chapter_titles.py
 
       - name: Rebuild FTS5 index
         run: |
-          docker run --rm -v "$(pwd)/data:/app/data" hts-local python3 << 'EOF'
+          docker run --rm --user root -v "$(pwd)/data:/app/data" hts-local python3 << 'EOF'
           import subprocess
           import sys
 


### PR DESCRIPTION
## Summary
- Adds `--user root` to the three Docker commands in `deploy-datasette.yml` that write to the bind-mounted `data/` volume (ingest, chapter titles enrichment, FTS5 rebuild)
- Matches the existing pattern in `refresh-hts-data.yml`, which already uses `--user root` for its data-writing commands
- Fixes permission failures in GitHub Actions where the runner user owns the `data/` directory and the container's non-root `appuser` cannot write to it

## Test plan
- [x] All 114 tests pass (`docker run --rm hts-local -m pytest tests/ -v`)
- [x] Verified `--user root` allows writing to the data volume locally
- [ ] Trigger the Deploy Datasette workflow manually to confirm the full pipeline succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)