### PR TITLE
fix: show real chapter titles in data-update notifications

### DIFF
--- a/.github/workflows/refresh-hts-data.yml
+++ b/.github/workflows/refresh-hts-data.yml
@@ -33,6 +33,7 @@ jobs:
           if [ ! -f "$(pwd)/data/hts.db" ]; then
             echo "Database not found. Running initial ingest..."
             docker run --rm --user root -v "$(pwd)/data:/app/data" hts-local scripts/ingest.py
+            docker run --rm --user root -v "$(pwd)/data:/app/data" hts-local scripts/chapter_titles.py
           else
             echo "Database found. Skipping ingest."
           fi
@@ -40,6 +41,10 @@ jobs:
       - name: Run refresh script
         run: |
           docker run --rm --user root -v "$(pwd)/data:/app/data" hts-local scripts/refresh.py
+
+      - name: Enrich chapter titles
+        run: |
+          docker run --rm --user root -v "$(pwd)/data:/app/data" hts-local scripts/chapter_titles.py
 
       - name: Check for changes
         id: check-changes


### PR DESCRIPTION
## Summary
- Run `chapter_titles.py` after refresh so the change-detection query reads enriched titles ("Live Animals") instead of placeholders ("Chapter 01")
- Also enrich titles after initial ingest in the same workflow, covering the cold-start path

Closes #37

## Test plan
- [ ] Trigger workflow manually via `workflow_dispatch` and verify the created issue shows real chapter titles
- [ ] Confirm `chapter_titles.py` is idempotent (existing tests cover this)

🤖 Generated with [Claude Code](https://claude.com/claude-code)