### PR TITLE
fix: chapter titles in refresh workflow notifications

### DIFF
--- a/.github/workflows/refresh-hts-data.yml
+++ b/.github/workflows/refresh-hts-data.yml
@@ -73,9 +73,11 @@ jobs:
       - name: Create issue for detected changes
         if: steps.check-changes.outputs.changes_detected == 'true'
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd
+        env:
+          CHANGED_CHAPTERS: ${{ steps.check-changes.outputs.changed_chapters }}
         with:
           script: >
-            const changed = JSON.parse('${{ steps.check-changes.outputs.changed_chapters }}');
+            const changed = JSON.parse(process.env.CHANGED_CHAPTERS);
             const chapters = changed.chapters || [];
 
             let chaptersMarkdown = '';


### PR DESCRIPTION
## Summary
- Enrich chapter titles before creating notification issues so descriptions show real names (e.g., "Live Animals") instead of generic "Chapter 01"
- Pass chapter JSON data via environment variable instead of direct `${{ }}` interpolation to fix JS `SyntaxError` caused by apostrophes in descriptions (e.g., "Pastrycooks' Products")

Fixes #37

## Test plan
- [ ] Trigger the refresh workflow manually via `gh workflow run refresh-hts-data.yml`
- [ ] Verify the "Create issue for detected changes" step completes without syntax errors
- [ ] Confirm the created issue shows enriched chapter titles

🤖 Generated with [Claude Code](https://claude.com/claude-code)