### PR TITLE
fix: use -m flag for datasette command in deploy workflow

### DIFF
--- a/.github/workflows/deploy-datasette.yml
+++ b/.github/workflows/deploy-datasette.yml
@@ -38,7 +38,7 @@ jobs:
             -e FLY_API_TOKEN="$FLY_API_TOKEN" \
             -v "$(pwd)/data:/app/data" \
             hts-local \
-            datasette publish fly \
+            -m datasette publish fly \
             data/hts.db \
             --app="tariff-everywhere" \
             --metadata metadata.json \


### PR DESCRIPTION
## Summary
- The deploy step failed because `datasette publish fly` was passed as args to the `python` entrypoint, making it `python datasette` — which errors with "can't open file"
- Fix: use `-m datasette` so Python runs it as a module

Fixes the failure in [run #23579075816](https://github.com/francisfuzz/tariff-everywhere/actions/runs/23579075816/job/68657952032)

## Test plan
- [ ] Trigger the `Deploy Datasette to Fly.io` workflow manually and confirm the deploy step passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)