### PR TITLE
fix: install flyctl on runner for Datasette deploy

### DIFF
--- a/.github/workflows/deploy-datasette.yml
+++ b/.github/workflows/deploy-datasette.yml
@@ -30,15 +30,17 @@ jobs:
         run: |
           docker run --rm --user root -v "$(pwd)/data:/app/data" hts-local scripts/build_fts.py
 
+      - name: Install flyctl
+        uses: superfly/flyctl-actions/setup-flyctl@master
+
+      - name: Install datasette and plugins
+        run: pip install datasette datasette-publish-fly datasette-search-all datasette-render-html
+
       - name: Deploy to Fly.io
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
         run: |
-          docker run --rm \
-            -e FLY_API_TOKEN="$FLY_API_TOKEN" \
-            -v "$(pwd)/data:/app/data" \
-            hts-local \
-            -m datasette publish fly \
+          datasette publish fly \
             data/hts.db \
             --app="tariff-everywhere" \
             --metadata metadata.json \


### PR DESCRIPTION
## Summary
- `datasette publish fly` requires `flyctl`, which isn't in the Docker container
- Install `flyctl` (via `superfly/flyctl-actions`) and `datasette` on the runner directly
- Data files are already on the host from the volume-mounted Docker steps (ingest, chapter titles, FTS)

Fixes the `flyctl` not found error from [run #23579227149](https://github.com/francisfuzz/tariff-everywhere/actions/runs/23579227149/job/68658392115)

## Test plan
- [ ] Merge and trigger the `Deploy Datasette to Fly.io` workflow manually
- [ ] Confirm the deploy step completes and https://tariff-everywhere.fly.dev/ is live

🤖 Generated with [Claude Code](https://claude.com/claude-code)